### PR TITLE
Update the liveness probe for server (api)

### DIFF
--- a/server/main.tf
+++ b/server/main.tf
@@ -195,7 +195,7 @@ resource "kubernetes_deployment" "server" {
 
           liveness_probe {
             http_get {
-              path = "/.well-known/apollo/server-health"
+              path = "/health"
               port = 3001
             }
 


### PR DESCRIPTION
Apollo Server 4 no longer supports built-in health checks, this means that the endpoint /.well-known/apollo/server-health is no longer supported. In https://github.com/serlo/api.serlo.org/pull/974 a new /health endpoint was added and can be now used.

Reference: https://www.apollographql.com/docs/apollo-server/migration/#health-checks.