### PR TITLE
refactor: Remove `serlo-org-database-layer-swr`

### DIFF
--- a/database-layer/main.tf
+++ b/database-layer/main.tf
@@ -2,10 +2,6 @@ locals {
   name = "serlo-org-database-layer"
 }
 
-variable "suffix" {
-  type = string
-}
-
 variable "namespace" {
   type = string
 }
@@ -44,13 +40,13 @@ variable "metadata_api_last_changes_date" {
 
 resource "kubernetes_service" "server" {
   metadata {
-    name      = "${local.name}${var.suffix}"
+    name      = "${local.name}"
     namespace = var.namespace
   }
 
   spec {
     selector = {
-      app = "${local.name}${var.suffix}"
+      app = "${local.name}"
     }
 
     port {
@@ -76,18 +72,18 @@ output "host" {
 
 resource "kubernetes_deployment" "server" {
   metadata {
-    name      = "${local.name}${var.suffix}"
+    name      = "${local.name}"
     namespace = var.namespace
 
     labels = {
-      app = "${local.name}${var.suffix}"
+      app = "${local.name}"
     }
   }
 
   spec {
     selector {
       match_labels = {
-        app = "${local.name}${var.suffix}"
+        app = "${local.name}"
       }
     }
 
@@ -103,7 +99,7 @@ resource "kubernetes_deployment" "server" {
     template {
       metadata {
         labels = {
-          app = "${local.name}${var.suffix}"
+          app = "${local.name}"
         }
       }
 
@@ -114,7 +110,7 @@ resource "kubernetes_deployment" "server" {
 
         container {
           image             = "eu.gcr.io/serlo-shared/serlo-org-database-layer:${var.image_tag}"
-          name              = "${local.name}${var.suffix}"
+          name              = "${local.name}"
           image_pull_policy = var.image_pull_policy
 
           liveness_probe {
@@ -177,7 +173,7 @@ resource "kubernetes_deployment" "server" {
 
 resource "kubernetes_horizontal_pod_autoscaler" "server" {
   metadata {
-    name      = "${local.name}${var.suffix}"
+    name      = "${local.name}"
     namespace = var.namespace
   }
 
@@ -187,7 +183,7 @@ resource "kubernetes_horizontal_pod_autoscaler" "server" {
     scale_target_ref {
       api_version = "apps/v1"
       kind        = "Deployment"
-      name        = "${local.name}${var.suffix}"
+      name        = "${local.name}"
     }
   }
 }

--- a/database-layer/main.tf
+++ b/database-layer/main.tf
@@ -40,7 +40,7 @@ variable "metadata_api_last_changes_date" {
 
 resource "kubernetes_service" "server" {
   metadata {
-    name      = "${local.name}"
+    name      = local.name
     namespace = var.namespace
   }
 
@@ -72,7 +72,7 @@ output "host" {
 
 resource "kubernetes_deployment" "server" {
   metadata {
-    name      = "${local.name}"
+    name      = local.name
     namespace = var.namespace
 
     labels = {
@@ -110,7 +110,7 @@ resource "kubernetes_deployment" "server" {
 
         container {
           image             = "eu.gcr.io/serlo-shared/serlo-org-database-layer:${var.image_tag}"
-          name              = "${local.name}"
+          name              = local.name
           image_pull_policy = var.image_pull_policy
 
           liveness_probe {
@@ -173,7 +173,7 @@ resource "kubernetes_deployment" "server" {
 
 resource "kubernetes_horizontal_pod_autoscaler" "server" {
   metadata {
-    name      = "${local.name}"
+    name      = local.name
     namespace = var.namespace
   }
 
@@ -183,7 +183,7 @@ resource "kubernetes_horizontal_pod_autoscaler" "server" {
     scale_target_ref {
       api_version = "apps/v1"
       kind        = "Deployment"
-      name        = "${local.name}"
+      name        = local.name
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,6 @@ module "secrets" {
 module "database_layer" {
   source = "./database-layer"
 
-  suffix            = ""
   namespace         = var.namespace
   image_tag         = var.database_layer.image_tag
   image_pull_policy = var.image_pull_policy

--- a/main.tf
+++ b/main.tf
@@ -135,22 +135,6 @@ module "database_layer" {
   metadata_api_last_changes_date = var.database_layer.metadata_api_last_changes_date
 }
 
-module "database_layer_swr" {
-  source = "./database-layer"
-
-  suffix            = "-swr"
-  namespace         = var.namespace
-  image_tag         = var.database_layer.image_tag
-  image_pull_policy = var.image_pull_policy
-  node_pool         = var.node_pool
-
-  environment                    = var.environment
-  sentry_dsn                     = var.database_layer.sentry_dsn
-  serlo_org_database_url         = var.database_layer.database_url
-  database_max_connections       = var.database_layer.database_max_connections
-  metadata_api_last_changes_date = var.database_layer.metadata_api_last_changes_date
-}
-
 module "server" {
   source = "./server"
 
@@ -198,7 +182,7 @@ module "swr_queue_worker" {
   google_spreadsheet_api        = var.google_spreadsheet_api
   rocket_chat_api               = var.rocket_chat_api
   mailchimp_api                 = var.mailchimp_api
-  serlo_org_database_layer_host = module.database_layer_swr.host
+  serlo_org_database_layer_host = module.database_layer.host
   concurrency                   = var.swr_queue_worker.concurrency
 }
 


### PR DESCRIPTION
I found the reason of this container: It is a copy of the database layer which uses the swr queue worker as endpoint instead of the regular database layer. Seeing the CPU usage of this container I don't think we currently need a duplication of it: 
![2023-11-06-192848_749x423_scrot](https://github.com/serlo/infrastructure-modules-api/assets/1327215/bbb47cca-eb66-454b-aff7-b81df31b39a5)
